### PR TITLE
allow scalar and 1d array arg mismatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
 ######################################################################
 # Makefile: GPU-Cornell Multigrid Coupled Tsunami (GPUCOMCOT) Model #
-# LAST REVISED: TAO CHIU  MARCH 2018                                #
 #####################################################################
 
 ### Plese specify your fortran compiler ##########################################
 FC          = gfortran
-FC_FLAGS    = -O2 #-fdefault-real-8 
+FC_FLAGS    = -fallow-argument-mismatch -O2 #-fdefault-real-8 
 ##################################################################################
 
 


### PR DESCRIPTION
let the compiler pass it as warning so at least we can have an executable